### PR TITLE
Test non fonctionnel

### DIFF
--- a/src/usr/lib/alternc/install.d/alternc-certbot
+++ b/src/usr/lib/alternc/install.d/alternc-certbot
@@ -5,7 +5,7 @@
 ## Load debconf
 . /usr/share/debconf/confmodule
 
-if [ $1 == "apache2" ]; then
+if [ "$1" == "apache2" ]; then
     db_get alternc-certbot/mail
     MAIL="$RET"
 


### PR DESCRIPTION
Éviter le message suivant :

`/usr/lib/alternc/install.d/alternc-certbot: line 8: [: ==: unary operator expected`