### PR TITLE
Remove and ignore debian/files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 debian/*.debhelper.log
 debian/*.substvars
 debian/alternc-certificate-provider-letsencrypt
+debian/files
 debian/.debhelper
 debian/debhelper-build-stamp
 *.gpg

--- a/debian/files
+++ b/debian/files
@@ -1,2 +1,0 @@
-alternc-certificate-provider-letsencrypt_0.0.15_all.deb admin optional
-alternc-certificate-provider-letsencrypt_0.0.15_amd64.buildinfo admin optional

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ endif
 
 clean:
 	dh clean
+	rm -f debian/files
 	git checkout debian/changelog
 	dch -m -b -v $(VERSION) autobuild
 


### PR DESCRIPTION
@see https://www.debian.org/doc/debian-policy/#generated-files-list-debian-files
debian/files should not be tracked in source control and is meant to be
a temporary file. Furthermore, the clean target should remove the file as well.