### PR TITLE
Reduce verbosity of the install.d/alternc-certbot

### DIFF
--- a/src/etc/cron.d/alternc-certbot
+++ b/src/etc/cron.d/alternc-certbot
@@ -1,4 +1,4 @@
 # Twice a day, every 12 hours :
 # - renew the certificate of the panel (alternc-cerbot)
 # - generate or renew the certificates of every domain available (generate_certbot.php via alternc-certbot)
-0 */12 * * *  root /usr/lib/alternc/install.d/alternc-certbot apache2
+0 */12 * * *  root /usr/lib/alternc/install.d/alternc-certbot apache2 --quiet

--- a/src/usr/lib/alternc/install.d/alternc-certbot
+++ b/src/usr/lib/alternc/install.d/alternc-certbot
@@ -22,5 +22,5 @@ if [ "$1" == "apache2" ]; then
     fi
 
     ##Generate let's encrypt certificate
-    /usr/lib/alternc/generate_certbot.php --verbose
+    /usr/lib/alternc/generate_certbot.php
 fi

--- a/src/usr/lib/alternc/install.d/alternc-certbot
+++ b/src/usr/lib/alternc/install.d/alternc-certbot
@@ -15,6 +15,13 @@ then
     fi
 fi
 
+# By default generate_certbot.php should be verbose, any caller may pass
+# --quiet to disable verbose output.
+VERBOSE='--verbose'
+if [[ " $@ " =~ " --quiet " ]] ; then
+    VERBOSE=''
+fi
+
 if [ "$1" == "apache2" ]; then
 
     if [ ! -d /var/lib/letsencrypt/ ]; then
@@ -22,5 +29,5 @@ if [ "$1" == "apache2" ]; then
     fi
 
     ##Generate let's encrypt certificate
-    /usr/lib/alternc/generate_certbot.php
+    /usr/lib/alternc/generate_certbot.php "$VERBOSE"
 fi


### PR DESCRIPTION
This is called directly as a cronjob and should be silent by default