### PR TITLE
fix test for locally hosted domain

### DIFF
--- a/src/usr/share/alternc/panel/class/m_certbot.php
+++ b/src/usr/share/alternc/panel/class/m_certbot.php
@@ -79,7 +79,7 @@ class m_certbot
     {
         global $L_PUBLIC_IP;
         $out=array();
-        exec("dig A +trace ".escapeshellarg($fqdn), $out);
+        exec("dig A ".escapeshellarg($fqdn), $out);
         foreach ($out as $line) {
             if (preg_match('#.*IN.A.*?([0-9\.]*)$#', $line, $mat) && $mat[1] == $L_PUBLIC_IP) {
                 return true;


### PR DESCRIPTION
this makes the ssl certificate generation work on my server. not sure why the +trace doesn't work, but I don't think it is needed in this case since we are just checking that the resolved ip matches the server's ip