### PR TITLE
Change parameter passed to generate_certbot.php to fix renewal

### DIFF
--- a/src/usr/lib/alternc/install.d/alternc-certbot
+++ b/src/usr/lib/alternc/install.d/alternc-certbot
@@ -32,7 +32,7 @@ fi
 # unless "--all" is passed.
 CERTS=""
 if [[ " $@ " =~ " --all " ]] ; then
-    CERTS="--certificates all"
+    CERTS="--certificates=all"
 fi
 
 if [ "$1" == "apache2" ]; then


### PR DESCRIPTION
Since the argument is quoted when generate_certbot.php is executed,
the value is incorrectly parsed by the receiving script. Adding in an
equals sign will make the argument parse correctly.

Fixes #53